### PR TITLE
forgives whitespace in currency list. Closes #1

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -26,7 +26,9 @@ const cli = meow(`
       USD: 261.91
 `);
 
-ethPrice(cli.input[0])
+const input = cli.input.map(item => item.replace(/,|\s+/g, '')).join(',');
+
+ethPrice(input)
 	.then(prices => {
 		spinner.stop();
 		prices.forEach(price => console.log(price));

--- a/test.js
+++ b/test.js
@@ -22,3 +22,11 @@ test('Get prices in format', async t => {
 	t.is(prices[0], 'USD: 260.21');
 	t.is(prices[1], 'BTC: 0.0973');
 });
+
+test('Forgives whitespace in currency list', async t => {
+	t.plan(2);
+
+	const prices = await fn('usd,     btc');
+	t.is(prices[0], 'USD: 260.21');
+	t.is(prices[1], 'BTC: 0.0973');
+});


### PR DESCRIPTION
This PR won't let the accidental or intentional space in the currency list break the output.

![image](https://user-images.githubusercontent.com/5614571/27001866-8b1d9736-4dcb-11e7-9f36-ce54e3faff11.png)
